### PR TITLE
Resized images in login page to be contained within screen size

### DIFF
--- a/LoginDetailsPage.js
+++ b/LoginDetailsPage.js
@@ -22,13 +22,19 @@ import {
     return (
       <View style={styles.body}>      
         <View style={styles.top}>
-          <Image style={styles.nusLogo}source={require('./assets/nuswhite2.png')}>
+          <Image style={styles.nusLogo}
+          resizeMode='contain'
+          source={require('./assets/nuswhite2.png')}>
           </Image>
         </View>
         <View style={styles.center}>
-          <Image style={styles.imageName}source={require('./assets/name.png')}>
+          <Image style={styles.imageName}
+          resizeMode='contain'
+          source={require('./assets/name.png')}>
           </Image>
-          <Image style={styles.imageLogo}source={require('./assets/logo.png')}>
+          <Image style={styles.imageLogo}
+          resizeMode='contain'
+          source={require('./assets/logo.png')}>
           </Image>
         </View>
 

--- a/NewPasswordPage.js
+++ b/NewPasswordPage.js
@@ -17,13 +17,19 @@ export default function NewPasswordPage({ navigation }) {
     return (
       <View style={styles.body}>      
         <View style={styles.top}>
-          <Image style={styles.nusLogo}source={require('./assets/nuswhite2.png')}>
+          <Image style={styles.nusLogo}
+          resizeMode='contain'
+          source={require('./assets/nuswhite2.png')}>
           </Image>
         </View>
         <View style={styles.center}>
-          <Image style={styles.imageName}source={require('./assets/name.png')}>
+          <Image style={styles.imageName}
+          resizeMode='contain'
+          source={require('./assets/name.png')}>
           </Image>
-          <Image style={styles.imageLogo}source={require('./assets/logo.png')}>
+          <Image style={styles.imageLogo}
+          resizeMode='contain'
+          source={require('./assets/logo.png')}>
           </Image>
         </View>
 

--- a/PasswordResetPage.js
+++ b/PasswordResetPage.js
@@ -17,13 +17,19 @@ export default function PasswordResetPage({ navigation }) {
     return (
       <View style={styles.body}>      
         <View style={styles.top}>
-          <Image style={styles.nusLogo}source={require('./assets/nuswhite2.png')}>
+          <Image style={styles.nusLogo}
+          resizeMode='contain'
+          source={require('./assets/nuswhite2.png')}>
           </Image>
         </View>
         <View style={styles.center}>
-          <Image style={styles.imageName}source={require('./assets/name.png')}>
+          <Image style={styles.imageName}
+          resizeMode='contain'
+          source={require('./assets/name.png')}>
           </Image>
-          <Image style={styles.imageLogo}source={require('./assets/logo.png')}>
+          <Image style={styles.imageLogo}
+          resizeMode='contain'
+          source={require('./assets/logo.png')}>
           </Image>
         </View>
 

--- a/SuccessfulPasswordResetPage.js
+++ b/SuccessfulPasswordResetPage.js
@@ -17,13 +17,19 @@ export default function SuccessfulPasswordResetPage({ navigation }) {
     return (
       <View style={styles.body}>      
         <View style={styles.top}>
-          <Image style={styles.nusLogo}source={require('./assets/nuswhite2.png')}>
+          <Image style={styles.nusLogo}
+          resizeMode='contain'
+          source={require('./assets/nuswhite2.png')}>
           </Image>
         </View>
         <View style={styles.center}>
-          <Image style={styles.imageName}source={require('./assets/name.png')}>
+          <Image style={styles.imageName}
+          resizeMode='contain'
+          source={require('./assets/name.png')}>
           </Image>
-          <Image style={styles.imageLogo}source={require('./assets/logo.png')}>
+          <Image style={styles.imageLogo}
+          resizeMode='contain'
+          source={require('./assets/logo.png')}>
           </Image>
         </View>
 

--- a/VerificationCodePage.js
+++ b/VerificationCodePage.js
@@ -17,13 +17,19 @@ export default function VerificationCodePage({ navigation }) {
     return (
       <View style={styles.body}>      
         <View style={styles.top}>
-          <Image style={styles.nusLogo}source={require('./assets/nuswhite2.png')}>
+          <Image style={styles.nusLogo}
+          resizeMode='contain'
+          source={require('./assets/nuswhite2.png')}>
           </Image>
         </View>
         <View style={styles.center}>
-          <Image style={styles.imageName}source={require('./assets/name.png')}>
+          <Image style={styles.imageName}
+          resizeMode='contain'
+          source={require('./assets/name.png')}>
           </Image>
-          <Image style={styles.imageLogo}source={require('./assets/logo.png')}>
+          <Image style={styles.imageLogo}
+          resizeMode='contain'
+          source={require('./assets/logo.png')}>
           </Image>
         </View>
 

--- a/loginPage.js
+++ b/loginPage.js
@@ -4,11 +4,12 @@ import {
   View,
   Text,
   Pressable,
-  Image, 
+  Image,
+  Dimensions, 
   
 } from 'react-native';
 
-export default function loginPage({ navigation }) {
+export default function LoginPage({ navigation }) {
     const onPressHandler = () => {
       navigation.navigate('LoginDetailsPage');
     }
@@ -20,13 +21,19 @@ export default function loginPage({ navigation }) {
     return (
       <View style={styles.body}>      
         <View style={styles.top}>
-          <Image style={styles.nusLogo}source={require('./assets/nuswhite2.png')}>
+          <Image style={styles.nusLogo}
+          resizeMode='contain'
+          source={require('./assets/nuswhite2.png')}>
           </Image>
         </View>
         <View style={styles.center}>
-          <Image style={styles.imageName}source={require('./assets/name.png')}>
+          <Image style={styles.imageName}
+          resizeMode='contain'
+          source={require('./assets/name.png')}>
           </Image>
-          <Image style={styles.imageLogo}source={require('./assets/logo.png')}>
+          <Image style={styles.imageLogo}
+          resizeMode='contain'
+          source={require('./assets/logo.png')}>
           </Image>
         </View>
   
@@ -109,6 +116,7 @@ const styles = StyleSheet.create({
 
   imageLogo: {
     flex:1,
+    //height: Dimensions.get('window').height,
     width:200,
     height:100,
   },


### PR DESCRIPTION
Changed the following pages images to be contained within screen size:
- LoginPage
- LoginDetailsPage
- NewPasswordPage
- PasswordResetPage
- SuccessfulPasswordResetPage
- VerificationCodePage

Currently, on iphone 8 size the image is cropped out, after this change image is scaled to fit screen size. Tested on Iphone 13 Pro Max size also the image should now fit any screen size.